### PR TITLE
Modularize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
 			"dependencies": {
 				"@types/node": "^18.8.4",
 				"discord.js": "^14.6.0",
-				"dotenv": "^16.0.3"
+				"dotenv": "^16.0.3",
+				"npmlog": "^6.0.2"
 			},
 			"devDependencies": {
+				"@types/npmlog": "^4.1.4",
 				"@typescript-eslint/eslint-plugin": "^5.40.0",
 				"@typescript-eslint/parser": "^5.40.0",
 				"eslint": "^8.25.0",
@@ -208,6 +210,12 @@
 			"version": "18.8.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
 			"integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow=="
+		},
+		"node_modules/@types/npmlog": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
+			"integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+			"dev": true
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.3",
@@ -443,7 +451,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -461,6 +468,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/aproba": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+		},
+		"node_modules/are-we-there-yet": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
 		"node_modules/argparse": {
@@ -560,11 +584,24 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -602,6 +639,11 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -661,6 +703,11 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -1024,6 +1071,24 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
+		"node_modules/gauge": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1106,6 +1171,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+		},
 		"node_modules/ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -1181,6 +1251,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-glob": {
@@ -1341,6 +1419,20 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"node_modules/npmlog": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"dependencies": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -1654,6 +1746,11 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -1674,6 +1771,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -1700,11 +1802,23 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -1892,6 +2006,14 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -2088,6 +2210,12 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.4.tgz",
 			"integrity": "sha512-WdlVphvfR/GJCLEMbNA8lJ0lhFNBj4SW3O+O5/cEGw9oYrv0al9zTwuQsq+myDUXgNx2jgBynoVgZ2MMJ6pbow=="
 		},
+		"@types/npmlog": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
+			"integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+			"dev": true
+		},
 		"@types/ws": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -2220,8 +2348,7 @@
 		"ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
 			"version": "4.3.0",
@@ -2230,6 +2357,20 @@
 			"dev": true,
 			"requires": {
 				"color-convert": "^2.0.1"
+			}
+		},
+		"aproba": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
+		},
+		"are-we-there-yet": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
 			}
 		},
 		"argparse": {
@@ -2308,11 +2449,21 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -2339,6 +2490,11 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -2386,6 +2542,11 @@
 			"version": "16.0.3",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
 			"integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+		},
+		"emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -2664,6 +2825,21 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
+		"gauge": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"requires": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			}
+		},
 		"glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2722,6 +2898,11 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2769,6 +2950,11 @@
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"is-glob": {
 			"version": "4.0.3",
@@ -2898,6 +3084,17 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true
+		},
+		"npmlog": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"requires": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			}
 		},
 		"once": {
 			"version": "1.4.0",
@@ -3076,6 +3273,11 @@
 				"lru-cache": "^6.0.0"
 			}
 		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+		},
 		"shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3090,6 +3292,11 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
 		"slash": {
 			"version": "3.0.0",
@@ -3110,11 +3317,20 @@
 				"safe-buffer": "~5.2.0"
 			}
 		},
+		"string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.1"
 			}
@@ -3244,6 +3460,14 @@
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
+			}
+		},
+		"wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"requires": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"word-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
 	"dependencies": {
 		"@types/node": "^18.8.4",
 		"discord.js": "^14.6.0",
-		"dotenv": "^16.0.3"
+		"dotenv": "^16.0.3",
+		"npmlog": "^6.0.2"
 	},
 	"devDependencies": {
+		"@types/npmlog": "^4.1.4",
 		"@typescript-eslint/eslint-plugin": "^5.40.0",
 		"@typescript-eslint/parser": "^5.40.0",
 		"eslint": "^8.25.0",

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1,7 +1,0 @@
-import { CommandInteraction } from "discord.js";
-
-export const emoji = { name: "emoji", description: "Emoji menüsünü açar" };
-
-export async function execute(interaction: CommandInteraction) {
-	await interaction.reply("todo!");
-}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 // TODO(admi): check if null & error
 
+import * as dotenv from "dotenv";
+dotenv.config();
+
 export const TOKEN: string = process.env["TOKEN"]!;
+export const TEST: boolean = process.env["TEST"] == "1";
+export const TEST_GUILD: string = process.env["TEST_GUILD"]!;

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,25 @@
+import log from "npmlog";
+
+export default class Logger {
+	private name: string;
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	debug(message: string, fields: { [key: string]: unknown }): void {
+		log.verbose(this.name, message, fields);
+	}
+
+	info(message: string, fields?: { [key: string]: unknown }): void {
+		log.info(this.name, message, fields);
+	}
+
+	warn(message: string, fields?: { [key: string]: unknown }): void {
+		log.warn(this.name, message, fields);
+	}
+
+	error(message: string, error?: Error, fields?: { [key: string]: unknown }) {
+		log.error(this.name, message, [fields, error]);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,41 +1,65 @@
-import * as _ from "dotenv";
-
-import { Client, GatewayIntentBits, REST, Routes } from "discord.js";
-import { emoji, execute as executeEmoji } from "./emoji";
 import * as env from "./env";
 
-// Reload and update slash commands
-(async () => {
-	const rest = new REST({ version: "10" }).setToken(env.TOKEN);
-	try {
-		console.log("Started refreshing application (/) commands.");
+import log from "npmlog";
+import { Client } from "discord.js";
 
-		await rest.put(Routes.applicationCommands("1029453218465456270"), {
-			body: [emoji],
+import { modules } from "./modules";
+
+log.level = env.TEST ? "verbose" : "info";
+log.stream = process.stdout;
+
+export const client = new Client({
+	intents: [],
+});
+
+function stop() {
+	log.info("", "stopping");
+
+	modules.forEach(module => {
+		if (module.subscribedTo.includes("quit")) {
+			module.logger.info("stopping");
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			module.quit();
+		}
+	});
+
+	client.destroy();
+	process.exit();
+}
+
+process.once("SIGINT", stop);
+process.once("SIGTERM", stop);
+
+modules.forEach(module => {
+	module.subscribedTo.forEach(event => {
+		module.logger.debug("registering handler", { event });
+
+		// this is handled somewhere else
+		if (event === "quit") {
+			return;
+		}
+
+		client.on(event, async (...args) => {
+			module.logger.debug("dispatching", { event });
+
+			try {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				await module[event](...args);
+			} catch (e) {
+				module.logger.error(`Error while dispatching`, e as Error, {
+					event,
+				});
+			}
 		});
-
-		console.log("Successfully reloaded application (/) commands.");
-	} catch (error) {
-		console.error(error);
-	}
-})();
-
-const { Guilds, MessageContent, GuildMessages, GuildMembers } =
-	GatewayIntentBits;
-
-const client = new Client({
-	intents: [Guilds, MessageContent, GuildMessages, GuildMembers],
+	});
 });
 
 client.on("ready", () => {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	console.log(`Logged in as ${client.user!.tag}`);
+	log.info("", `Logged in as ${client.user!.tag}`);
 });
 
-client.on("interactionCreate", async interaction => {
-	if (!interaction.isChatInputCommand()) return;
-
-	if (interaction.commandName === "emoji") await executeEmoji(interaction);
-});
-
+log.info("", "Trying to log in");
 client.login(env.TOKEN);

--- a/src/modules/emoji.ts
+++ b/src/modules/emoji.ts
@@ -1,0 +1,24 @@
+import { CommandInteraction } from "discord.js";
+import { Module } from ".";
+import Logger from "../log";
+import { registerSlashCommand } from "../util/cmd";
+
+export default class implements Module {
+	name = "emoji";
+	subscribedTo = ["ready", "interactionCreate"];
+	logger = new Logger(this.name);
+
+	async ready() {
+		await registerSlashCommand({
+			name: "emoji",
+			description: "Emoji menüsünü açar",
+		});
+	}
+
+	async interactionCreate(inter: CommandInteraction) {
+		if (!inter.isCommand()) return;
+		if (inter.commandName != "emoji") return;
+
+		await inter.reply("todo!");
+	}
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,7 +1,11 @@
 import Logger from "../log";
 
+import EmojiModule from "./emoji";
+
 export const modules: Module[] = [
 	/* don't forget to add new modules here */
+
+	new EmojiModule(),
 ];
 
 export interface Module {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,15 @@
+import Logger from "../log";
+
+export const modules: Module[] = [
+	/* don't forget to add new modules here */
+];
+
+export interface Module {
+	name: string;
+	subscribedTo: string[];
+	logger: Logger;
+}
+
+export function getModule(name: string): Module | undefined {
+	return modules.find(m => m.name === name);
+}

--- a/src/util/cmd.ts
+++ b/src/util/cmd.ts
@@ -1,0 +1,21 @@
+import { ApplicationCommandData, Snowflake } from "discord.js";
+import log from "npmlog";
+import { client } from "../main";
+import * as env from "../env";
+
+export async function registerSlashCommand(
+	cmd: ApplicationCommandData
+): Promise<void> {
+	if (env.TEST) {
+		log.verbose(
+			"",
+			"Test Mode! Registering slash command only for test guild!"
+		);
+
+		await (
+			await client.guilds.fetch(env.TEST_GUILD as Snowflake)
+		).commands.create(cmd);
+	} else {
+		await client.application?.commands.create(cmd);
+	}
+}

--- a/tools/delcommand.cjs
+++ b/tools/delcommand.cjs
@@ -1,0 +1,14 @@
+const { REST, Routes } = require("discord.js");
+const env = require("../out/env.js");
+
+const rest = new REST({ version: "10" }).setToken(env.TOKEN);
+
+rest.put(
+	Routes.applicationGuildCommands(
+		process.env["T_DELCOMMAND_CLIENT"],
+		process.env["T_DELCOMMAND_GUILD"]
+	),
+	{ body: [] }
+)
+	.then(() => console.log("Successfully deleted all guild commands."))
+	.catch(console.error);


### PR DESCRIPTION
Module system works reasonably well, turned `emoji` into a module.

I'm worried about how command registration should work. Currently, we're registering commands on each start, but this is apparently unnecessary (?)

> Since commands only need to be registered once, and updated when the definition (description, options etc) is changed, it's not necessary to connect a whole client to the gateway or do this on every ready event.

I've also added in a tool you can run with `npm run tool delcommand` that deletes all commands currently registered.